### PR TITLE
[codex] sharpen portfolio positioning

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,4 @@
+{
+  "recommendations": ["astro-build.astro-vscode"],
+  "unwantedRecommendations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "./node_modules/.bin/astro dev",
+      "name": "Development server",
+      "request": "launch",
+      "type": "node-terminal"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,43 +1,33 @@
-# Astro Starter Kit: Minimal
+# Anthony Abusa Portfolio
 
-```sh
-npm create astro@latest -- --template minimal
+Astro-powered personal portfolio for Anthony Abusa: consulting, entrepreneurship, projects, and writing.
+
+Live site: https://anthonyabusa.github.io
+
+## Stack
+
+- Astro 6
+- Tailwind CSS 4
+- GitHub Pages deploy via GitHub Actions
+- Node >= 22.12
+
+## Commands
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run preview
 ```
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Content map
 
-## 🚀 Project Structure
+- `src/pages/` — route pages
+- `src/components/` — reusable UI cards, nav, footer, reveal behavior
+- `src/data/projects.json` — project cards shown on home/projects
+- `src/content/blog/` — Markdown blog posts
+- `public/` — static assets
 
-Inside of your Astro project, you'll see the following folders and files:
+## Deploy
 
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Pushing to `master` triggers `.github/workflows/deploy.yml` and publishes to GitHub Pages.

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -30,6 +30,26 @@
     "type": "automation"
   },
   {
+    "title": "HealthRise Global ML/AI",
+    "description": "ML and AI integration across global healthcare programs operating in India, Brazil, South Africa, and Ethiopia — embedding predictive tools into operations serving hundreds of thousands of patients.",
+    "url": "",
+    "liveUrl": "",
+    "tags": ["ML/AI", "Healthcare", "Global Programs", "Integration"],
+    "featured": true,
+    "year": 2021,
+    "type": "program"
+  },
+  {
+    "title": "Johnson Matthey Transformation",
+    "description": "Led 12 enterprise transformation programs at a global specialty chemicals manufacturer, driving +37% process efficiency. Founded the North America Government Affairs function from scratch.",
+    "url": "",
+    "liveUrl": "",
+    "tags": ["Strategy", "Operations", "Government Affairs", "Program Management"],
+    "featured": true,
+    "year": 2020,
+    "type": "program"
+  },
+  {
     "title": "Personal Portfolio",
     "description": "This Astro-powered site: a living portfolio for projects, writing, and public proof-of-work rather than a static resume page.",
     "url": "https://github.com/anthonyabusa/anthonyabusa.github.io",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,32 +1,42 @@
 [
   {
-    "title": "OpenClaw Framework",
-    "description": "A personal AI agent infrastructure running on macOS — gateway, memory, Discord bot, and dashboard, all orchestrated as a self-managing system.",
-    "url": "https://github.com/anthonyabusa",
-    "liveUrl": "",
-    "tags": ["AI", "Node.js", "Python", "Automation"],
-    "featured": true,
-    "year": 2025,
-    "type": "product"
-  },
-  {
     "title": "Navore Market",
-    "description": "Pre-seed food marketplace startup based in San Diego — connecting local food producers with consumers through a modern, mobile-first platform.",
-    "url": "https://github.com/anthonyabusa",
-    "liveUrl": "",
-    "tags": ["Startup", "Marketplace", "Strategy"],
+    "description": "A San Diego food marketplace connecting local producers with consumers through a modern, mobile-first operating model. USDA-backed and built around real logistics, trust, and neighborhood demand.",
+    "url": "https://navoremarket.com",
+    "liveUrl": "https://navoremarket.com",
+    "tags": ["Startup", "Marketplace", "Food", "Operations"],
     "featured": true,
-    "year": 2025,
-    "type": "product"
+    "year": 2026,
+    "type": "venture"
   },
   {
-    "title": "Crypto Trading Bot",
-    "description": "An automated Kraken trading bot with configurable strategies, real-time monitoring, and a live dashboard for portfolio tracking.",
-    "url": "https://github.com/anthonyabusa",
+    "title": "OpenClaw Framework",
+    "description": "Personal AI infrastructure for agent workflows: gateway, memory RAG, Discord collaboration, dashboard visibility, scheduled briefs, and local/remote machine orchestration.",
+    "url": "https://github.com/Busa-Legacies/Ant-openclaw-framework",
     "liveUrl": "",
-    "tags": ["Python", "Trading", "Automation", "Finance"],
+    "tags": ["AI Agents", "Python", "Node.js", "Automation"],
     "featured": true,
-    "year": 2024,
-    "type": "product"
+    "year": 2026,
+    "type": "infrastructure"
+  },
+  {
+    "title": "Kraken Trading Bot",
+    "description": "A paper-first crypto trading system with strategy gates, sentiment filters, Kelly-style sizing, dry-run safety, and dashboard monitoring before any live deployment.",
+    "url": "https://github.com/Busa-Legacies/Ant-openclaw-framework/tree/main/projects/trading-bot",
+    "liveUrl": "",
+    "tags": ["Python", "Trading", "Risk", "Dashboards"],
+    "featured": true,
+    "year": 2026,
+    "type": "automation"
+  },
+  {
+    "title": "Personal Portfolio",
+    "description": "This Astro-powered site: a living portfolio for projects, writing, and public proof-of-work rather than a static resume page.",
+    "url": "https://github.com/anthonyabusa/anthonyabusa.github.io",
+    "liveUrl": "https://anthonyabusa.github.io",
+    "tags": ["Astro", "Design", "Writing"],
+    "featured": false,
+    "year": 2026,
+    "type": "site"
   }
 ]

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,35 +6,35 @@ const expertise = [
   {
     icon: '↗',
     title: 'Strategy & Operations',
-    description: 'Market analysis, operating models, financial planning, and execution systems for early-stage and scaling organizations.',
+    description: 'Market design, GTM planning, operating models, and execution rhythms for teams that need traction, not theater.',
   },
   {
     icon: '◈',
     title: 'Product & Program Leadership',
-    description: 'Cross-functional roadmaps, vendor management, launch planning, and delivery discipline across technical and business teams.',
+    description: 'Turning messy ideas into scoped releases, roadmaps, feedback loops, dashboards, and repeatable delivery.',
   },
   {
     icon: '✦',
     title: 'AI & Automation',
-    description: 'Applied AI systems, automation workflows, analytics, and tooling that reduce operational friction and improve decision-making.',
+    description: 'Designing agent workflows, memory systems, analytics, and automations that reduce operational drag.',
   },
   {
     icon: '◎',
     title: 'Marketplace & Venture Building',
-    description: 'Hands-on experience building local food marketplace infrastructure, producer operations, grant programs, and growth systems.',
+    description: 'Hands-on founder work building local food marketplace infrastructure, producer operations, grants, and growth systems.',
   },
 ];
 
 const skills = {
-  Business: ['Strategy', 'GTM Planning', 'Financial Modeling', 'Operations', 'Market Research'],
-  Technical: ['Python', 'TypeScript', 'SQL', 'APIs', 'AI/ML', 'Analytics'],
-  Tools: ['ClickUp', 'GitHub', 'Tableau', 'RStudio', 'Notion', 'GA4'],
+  Business: ['Marketplaces', 'GTM Planning', 'Financial Modeling', 'Operations', 'Fundraising'],
+  Technical: ['Python', 'TypeScript', 'Node.js', 'Astro', 'AI Agents', 'APIs'],
+  Tools: ['GitHub', 'ClickUp', 'FastAPI', 'Ollama', 'Discord Bots', 'Kraken API'],
 };
 ---
 
 <BaseLayout
   title="About"
-  description="Anthony Abusa — strategy, operations, and technology leader. Background in chemical engineering, business strategy, product execution, and AI-driven systems."
+  description="Anthony Abusa — San Diego founder/operator building Navore Market, OpenClaw AI infrastructure, and practical automation systems."
 >
   <div class="max-w-5xl mx-auto px-6 pt-32 pb-24">
 
@@ -48,7 +48,7 @@ const skills = {
     <div class="reveal grid md:grid-cols-3 gap-12 mb-20">
       <div class="md:col-span-2 space-y-5 text-[#94A3B8] leading-relaxed">
         <p>
-          I'm Anthony Abusa — a San Diego-based strategy and operations leader working at the intersection of business, technology, and product execution.
+          I'm Anthony Abusa — a San Diego-based founder and operator working at the intersection of business strategy, product execution, and automation.
         </p>
         <p>
           My background spans chemical engineering, a quantitative MBA, corporate strategy, startup operations, and technical program management. That mix helps me move between systems-level technical thinking and the commercial realities that determine whether products and organizations actually work.
@@ -57,7 +57,7 @@ const skills = {
           Today, I help build and scale <strong class="text-[#F1F5F9]">Navore Market</strong>, a local food marketplace connecting San Diego producers with consumers. My work spans strategy, operations, grant execution, product roadmap, analytics, distribution design, and cross-functional execution.
         </p>
         <p>
-          I'm especially interested in the way AI, automation, and better operating systems can help small teams move with more leverage, clarity, and resilience.
+          I'm also building <strong class="text-[#F1F5F9]">OpenClaw</strong>, a personal AI operations stack for agents, memory, dashboards, Discord workflows, and automation. It is part lab, part operating system, and part proof that small teams can run with much more leverage.
         </p>
         <div class="pt-4">
           <SocialLinks />
@@ -77,7 +77,7 @@ const skills = {
       <div class="reveal-group grid sm:grid-cols-2 gap-5">
         {expertise.map((item) => (
           <div class="reveal p-6 rounded-xl border border-[#1E2640] bg-[#141928]">
-            <div class="text-2xl mb-3 text-[#F59E0B] font-mono">{item.icon}</div>
+            <div class="text-2xl mb-3">{item.icon}</div>
             <h3 class="text-[#F1F5F9] font-semibold mb-2">{item.title}</h3>
             <p class="text-[#64748B] text-sm leading-relaxed">{item.description}</p>
           </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -54,10 +54,13 @@ const skills = {
           My background spans chemical engineering, a quantitative MBA, corporate strategy, startup operations, and technical program management. That mix helps me move between systems-level technical thinking and the commercial realities that determine whether products and organizations actually work.
         </p>
         <p>
-          Today, I help build and scale <strong class="text-[#F1F5F9]">Navore Market</strong>, a local food marketplace connecting San Diego producers with consumers. My work spans strategy, operations, grant execution, product roadmap, analytics, distribution design, and cross-functional execution.
+          Today, I help build and scale <strong class="text-[#F1F5F9]">Navore Market</strong>, a local food marketplace connecting San Diego producers with consumers. My work spans strategy, operations, USDA grant execution, product roadmap, analytics, distribution design, and cross-functional execution.
         </p>
         <p>
           I'm also building <strong class="text-[#F1F5F9]">OpenClaw</strong>, a personal AI operations stack for agents, memory, dashboards, Discord workflows, and automation. It is part lab, part operating system, and part proof that small teams can run with much more leverage.
+        </p>
+        <p>
+          Before startups: led 12 transformation programs at <strong class="text-[#F1F5F9]">Johnson Matthey</strong> (global specialty chemicals) driving +37% process efficiency, and founded the North America Government Affairs function there from scratch. Worked with <strong class="text-[#F1F5F9]">HealthRise</strong> on ML/AI integration across global healthcare programs operating in India, Brazil, South Africa, and Ethiopia.
         </p>
         <div class="pt-4">
           <SocialLinks />
@@ -82,6 +85,29 @@ const skills = {
             <p class="text-[#64748B] text-sm leading-relaxed">{item.description}</p>
           </div>
         ))}
+      </div>
+    </div>
+
+    <div class="reveal mb-20">
+      <p class="text-[#F59E0B] font-mono text-xs tracking-widest uppercase mb-3">Recognition</p>
+      <h2 class="text-2xl font-bold text-[#F1F5F9] mb-8">Background & Honors</h2>
+      <div class="space-y-4 text-[#94A3B8] text-sm leading-relaxed">
+        <div class="flex gap-4 items-start">
+          <span class="text-[#F59E0B] font-mono text-xs mt-1 shrink-0 w-32">2018</span>
+          <p><strong class="text-[#F1F5F9]">Forbes 30 Under 30 Scholar</strong> — JPMorgan Chase, Consumer & Retail track. Selected from a national applicant pool.</p>
+        </div>
+        <div class="flex gap-4 items-start">
+          <span class="text-[#F59E0B] font-mono text-xs mt-1 shrink-0 w-32">Education</span>
+          <p><strong class="text-[#F1F5F9]">Carnegie Mellon University</strong> — MBA, Tepper School (quantitative focus). <strong class="text-[#F1F5F9]">Villanova University</strong> — B.S. Chemical Engineering (Student Body President; built student government structure from the ground up).</p>
+        </div>
+        <div class="flex gap-4 items-start">
+          <span class="text-[#F59E0B] font-mono text-xs mt-1 shrink-0 w-32">Recognition</span>
+          <p><strong class="text-[#F1F5F9]">Google Cloud Student Innovator</strong>. Photojournalism exhibit on globalization — fieldwork in Tibet and Mongolia.</p>
+        </div>
+        <div class="flex gap-4 items-start">
+          <span class="text-[#F59E0B] font-mono text-xs mt-1 shrink-0 w-32">Interests</span>
+          <p>AI systems architecture · backpacking · 3D printing · swimming · strategy writing</p>
+        </div>
       </div>
     </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const recentPosts = posts
 
 <BaseLayout
   title="Home"
-  description="Anthony Abusa — strategy and operations leader building technology-enabled systems across startups, marketplaces, AI workflows, and business strategy."
+  description="Anthony Abusa — San Diego founder and operator building Navore Market, OpenClaw AI infrastructure, and practical automation systems."
 >
   <!-- Hero -->
   <section class="relative min-h-screen flex items-center hero-grid overflow-hidden">
@@ -28,16 +28,16 @@ const recentPosts = posts
 
     <div class="relative max-w-5xl mx-auto px-6 pt-28 pb-20 w-full">
       <p class="text-[#F59E0B] font-mono text-sm tracking-widest uppercase mb-6 opacity-0 animate-[fadeUp_0.6s_ease_0.1s_forwards]">
-        San Diego, California
+        San Diego founder · operator · systems builder
       </p>
 
       <h1 class="text-5xl md:text-7xl font-bold leading-[1.05] tracking-tight mb-6 opacity-0 animate-[fadeUp_0.6s_ease_0.25s_forwards]">
-        <span class="text-[#F1F5F9]">Anthony</span><br />
-        <span class="gradient-text">Abusa.</span>
+        <span class="text-[#F1F5F9]">Building useful</span><br />
+        <span class="gradient-text">systems.</span>
       </h1>
 
-      <p class="text-xl md:text-2xl text-[#64748B] max-w-3xl leading-relaxed mb-10 opacity-0 animate-[fadeUp_0.6s_ease_0.4s_forwards]">
-        Strategy & operations leader building technology-enabled systems across startups, marketplaces, AI workflows, and business strategy.
+      <p class="text-xl md:text-2xl text-[#94A3B8] max-w-2xl leading-relaxed mb-10 opacity-0 animate-[fadeUp_0.6s_ease_0.4s_forwards]">
+        I'm Anthony Abusa — founder of Navore Market and builder of OpenClaw, a personal AI operations stack. I work where strategy, product, and automation meet.
       </p>
 
       <div class="flex flex-wrap gap-4 opacity-0 animate-[fadeUp_0.6s_ease_0.55s_forwards]">
@@ -45,14 +45,14 @@ const recentPosts = posts
           href="/projects"
           class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-[#F59E0B] text-[#0B0F1A] font-semibold text-sm hover:bg-[#D97706] transition-colors"
         >
-          View Work
+          View Projects
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
         <a
           href="/blog"
           class="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-[#1E2640] text-[#94A3B8] text-sm hover:border-[#F59E0B] hover:text-[#F59E0B] transition-colors"
         >
-          Read Writing
+          Read Notes
         </a>
       </div>
 
@@ -65,9 +65,10 @@ const recentPosts = posts
   <!-- Stats strip -->
   <section class="max-w-5xl mx-auto px-6 py-20">
     <div class="reveal-group grid grid-cols-2 md:grid-cols-4 gap-4">
-      <StatCounter value={11} suffix="+" label="Years of Experience" />
-      <StatCounter value={9} suffix="+" label="Companies advised" />
-      <StatCounter value={5} label="Products launched" />
+      <StatCounter value={11} suffix="+" label="Years of experience" />
+      <StatCounter value={471} suffix="k" label="USDA-backed Navore funding" />
+      <StatCounter value={3} label="Active product systems" />
+      <StatCounter value={100} suffix="%" label="Built in public" />
     </div>
   </section>
 
@@ -78,9 +79,9 @@ const recentPosts = posts
         AA
       </div>
       <div>
-        <h2 class="text-xl font-semibold text-[#F1F5F9] mb-3">Hey, I'm Anthony.</h2>
+        <h2 class="text-xl font-semibold text-[#F1F5F9] mb-3">I turn ambiguous ideas into operating systems.</h2>
         <p class="text-[#64748B] leading-relaxed mb-4">
-          I work at the intersection of business strategy, operations, and technology — helping teams translate complex ideas into systems, roadmaps, and products that can actually scale.
+          My work spans marketplace execution, AI infrastructure, and practical automation. The throughline: make the work visible, make the system reliable, and ship the next useful version.
         </p>
         <a href="/about" class="text-sm text-[#F59E0B] hover:text-[#D97706] transition-colors font-medium">
           More about me →
@@ -93,8 +94,8 @@ const recentPosts = posts
   <section class="max-w-5xl mx-auto px-6 pb-24">
     <div class="flex items-end justify-between mb-10">
       <div>
-        <p class="text-[#F59E0B] font-mono text-xs tracking-widest uppercase mb-2">Selected Work</p>
-        <h2 class="text-3xl font-bold text-[#F1F5F9]">Projects</h2>
+        <p class="text-[#F59E0B] font-mono text-xs tracking-widest uppercase mb-2">Current Builds</p>
+        <h2 class="text-3xl font-bold text-[#F1F5F9]">What I'm building</h2>
       </div>
       <a href="/projects" class="text-sm text-[#64748B] hover:text-[#F59E0B] transition-colors">
         View all →
@@ -138,10 +139,10 @@ const recentPosts = posts
     <div class="reveal text-center p-14 rounded-2xl border border-[#1E2640] bg-[#141928] relative overflow-hidden">
       <div class="absolute inset-0 bg-gradient-to-br from-[#F59E0B]/5 via-transparent to-transparent pointer-events-none" />
       <h2 class="relative text-3xl md:text-4xl font-bold text-[#F1F5F9] mb-4">
-        Let's build something.
+Have an ambitious system to build?
       </h2>
       <p class="relative text-[#64748B] mb-8 max-w-sm mx-auto">
-        Whether it's a new venture, a strategy challenge, or a product idea — I'd love to hear about it.
+If it needs strategy, software, and operator-level follow-through, that's my lane.
       </p>
       <a
         href="/contact"

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -24,7 +24,7 @@ const allTags = [...new Set(projects.flatMap((p) => p.tags))].sort();
 
 <BaseLayout
   title="Projects"
-  description="A selection of products, consulting work, and open-source projects by Anthony Abusa."
+  description="Active ventures, AI infrastructure, automation systems, and public proof-of-work by Anthony Abusa."
 >
   <div class="max-w-5xl mx-auto px-6 pt-32 pb-24">
 
@@ -32,7 +32,7 @@ const allTags = [...new Set(projects.flatMap((p) => p.tags))].sort();
       <p class="text-[#F59E0B] font-mono text-xs tracking-widest uppercase mb-4">Portfolio</p>
       <h1 class="text-4xl md:text-5xl font-bold text-[#F1F5F9] mb-4">Projects</h1>
       <p class="text-[#64748B] max-w-lg">
-        A mix of products I've built, systems I've automated, and ventures I'm running.
+        Active ventures, infrastructure, and automation systems — the work I'm operating, not just the work I finished.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

- Repositions the homepage around founder/operator/system-builder work instead of generic consulting copy.
- Updates About copy to foreground Navore Market, OpenClaw, marketplace execution, and AI automation.
- Refreshes project data with current builds: Navore Market, OpenClaw, Kraken Trading Bot, and the portfolio itself.
- Tightens Projects page metadata and intro copy.

## Validation

- `npm run build`
